### PR TITLE
polling: fix incorrect reference, error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "matrox-monarch",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"main": "index.js",
 	"scripts": {
 		"format": "prettier --write .",

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -10,6 +10,8 @@ module.exports = {
 
 		let feedbacks = {}
 
+		let self = this;
+
 		switch (this.config.device_type) {
 			case 'monarch-hd':
 			case 'nvs-30':
@@ -36,7 +38,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`recorder_status`)
+						const currentValue = self.getVariableValue(`recorder_status`)
 						return currentValue == opt.state
 					},
 				}
@@ -64,7 +66,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`stream_status`)
+						const currentValue = self.getVariableValue(`stream_status`)
 						return currentValue == opt.state
 					},
 				}
@@ -92,7 +94,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`stream_type`)
+						const currentValue = self.getVariableValue(`stream_type`)
 						return currentValue == opt.state
 					},
 				}
@@ -122,7 +124,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`filetranfser_state`)
+						const currentValue = self.getVariableValue(`filetranfser_state`)
 						return currentValue == opt.state
 					},
 				}
@@ -150,7 +152,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`encoder_1_status`)
+						const currentValue = self.getVariableValue(`encoder_1_status`)
 						return currentValue == opt.state
 					},
 				}
@@ -179,7 +181,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`encoder_2_status`)
+						const currentValue = self.getVariableValue(`encoder_2_status`)
 						return currentValue == opt.state
 					},
 				}
@@ -207,7 +209,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`encoder_1_type`)
+						const currentValue = self.getVariableValue(`encoder_1_type`)
 						return currentValue == opt.state
 					},
 				}
@@ -235,7 +237,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`encoder_2_type`)
+						const currentValue = self.getVariableValue(`encoder_2_type`)
 						return currentValue == opt.state
 					},
 				}
@@ -264,7 +266,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`encoder_1_status`)
+						const currentValue = self.getVariableValue(`encoder_1_status`)
 						return currentValue == opt.state
 					},
 				}
@@ -292,7 +294,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`encoder_2_status`)
+						const currentValue = self.getVariableValue(`encoder_2_status`)
 						return currentValue == opt.state
 					},
 				}
@@ -320,7 +322,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`encoder_1_type`)
+						const currentValue = self.getVariableValue(`encoder_1_type`)
 						return currentValue == opt.state
 					},
 				}
@@ -348,7 +350,7 @@ module.exports = {
 					],
 					callback: function (feedback) {
 						let opt = feedback.options
-						const currentValue = this.getVariableValue(`encoder_2_type`)
+						const currentValue = self.getVariableValue(`encoder_2_type`)
 						return currentValue == opt.state
 					},
 				}


### PR DESCRIPTION
The `sendCommand` function expects to receive an object with an `actionId` parameter, which was causing the polling command to send an API with the query string `undefined`.
Also added a try/catch block to the polling to fix the error handling when the connection fails (the module was crashing).

Also fixes incorrect reference to get the variables in feedbacks, and now checks feedbacks with polling.